### PR TITLE
fix: filtering failed when input is empty

### DIFF
--- a/fuzzy.ts
+++ b/fuzzy.ts
@@ -63,7 +63,7 @@ export function findAllMatches(
       }
       return thresholdFilter(newPosList);
     },
-    thresholdFilter(h.get(pattern[0])!.map((c) => [c])),
+    thresholdFilter(h.get(pattern[0])?.map((c) => [c]) ?? []),
   );
   return posList.map((pos): Match => ({
     pos,


### PR DESCRIPTION
In case of pattern length is zero(e.g. minCompleteLength is zero or forceCompletionPattern is set), result of `h.get(pattern[0])` is undefined. Therefore, `map` fail.
This PR is fix to fallback to empty array.